### PR TITLE
Connection UI Changes [append to #6]

### DIFF
--- a/scenes/components/multiplayer_connection/multiplayer_connection.gd
+++ b/scenes/components/multiplayer_connection/multiplayer_connection.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Control
 class_name MultiplayerConnection
 
 ## [server only] Emitted when a client connects to the server
@@ -11,14 +11,15 @@ var multiplayer_peer = ENetMultiplayerPeer.new()
 var url: String = "127.0.0.1"
 const PORT: int = 9009
 
-@onready var host_input: TextEdit = $HostInput
-@onready var connect_btn: Button = $ConnectBtn
+@onready var host_input: TextEdit = $Connect/HostInput
+@onready var connect_btn: Button = $Connect/ConnectBtn
 @onready var disconnect_btn: Button = $DisconnectBtn
 
 func _ready() -> void:
 	update_connection_buttons()
 	if OS.has_feature("is_server"):
 		setup_server_connection()
+		$Connect.hide()
 	else:
 		setup_client_connection()
 
@@ -70,12 +71,14 @@ func update_connection_buttons() -> void:
 		return
 	
 	if multiplayer_peer.get_connection_status() == multiplayer_peer.CONNECTION_DISCONNECTED:
+		$Connect.show()
 		connect_btn.disabled = false
 		disconnect_btn.disabled = true
 	if multiplayer_peer.get_connection_status() == multiplayer_peer.CONNECTION_CONNECTING:
 		connect_btn.disabled = true
 		disconnect_btn.disabled = true
 	if multiplayer_peer.get_connection_status() == multiplayer_peer.CONNECTION_CONNECTED:
+		$Connect.hide()
 		connect_btn.disabled = true
 		disconnect_btn.disabled = false
 

--- a/scenes/components/multiplayer_connection/multiplayer_connection.tscn
+++ b/scenes/components/multiplayer_connection/multiplayer_connection.tscn
@@ -2,30 +2,69 @@
 
 [ext_resource type="Script" path="res://scenes/components/multiplayer_connection/multiplayer_connection.gd" id="1_22lmt"]
 
-[node name="MultiplayerConnection" type="Node"]
+[node name="MultiplayerConnection" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 script = ExtResource("1_22lmt")
 
-[node name="HostInput" type="TextEdit" parent="."]
-offset_left = 6.0
-offset_top = 3.0
-offset_right = 216.0
-offset_bottom = 40.0
-text = "127.0.0.1"
+[node name="Connect" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -178.5
+offset_top = -17.5
+offset_right = 178.5
+offset_bottom = 17.5
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 
-[node name="ConnectBtn" type="Button" parent="."]
-offset_left = 6.0
-offset_top = 50.0
-offset_right = 105.0
-offset_bottom = 81.0
+[node name="ServerIP" type="Label" parent="Connect"]
+layout_mode = 2
+text = "Server IP:"
+
+[node name="HostInput" type="TextEdit" parent="Connect"]
+custom_minimum_size = Vector2(192, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+text = "127.0.0.1"
+placeholder_text = "SERVER_IP"
+scroll_fit_content_height = true
+
+[node name="Spacer" type="Control" parent="Connect"]
+custom_minimum_size = Vector2(8, 8)
+layout_mode = 2
+
+[node name="ConnectBtn" type="Button" parent="Connect"]
+layout_mode = 2
 text = "Connect
 "
 
 [node name="DisconnectBtn" type="Button" parent="."]
-offset_left = 121.0
-offset_top = 49.0
-offset_right = 215.0
-offset_bottom = 80.0
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -102.0
+offset_top = -38.0
+offset_right = -8.0
+offset_bottom = -7.0
+grow_horizontal = 0
+grow_vertical = 0
 text = "Disconnect"
 
-[connection signal="pressed" from="ConnectBtn" to="." method="_on_connect_btn_pressed"]
+[connection signal="pressed" from="Connect/ConnectBtn" to="." method="_on_connect_btn_pressed"]
 [connection signal="pressed" from="DisconnectBtn" to="." method="_on_disconnect_btn_pressed"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -6,7 +6,9 @@
 
 [node name="Main" type="Node2D"]
 
-[node name="MultiplayerConnection" parent="." instance=ExtResource("3_qakxp")]
+[node name="HUD" type="CanvasLayer" parent="."]
+
+[node name="MultiplayerConnection" parent="HUD" instance=ExtResource("3_qakxp")]
 
 [node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="."]
 _spawnable_scenes = PackedStringArray("res://scenes/characters/player.tscn")
@@ -25,14 +27,14 @@ position = Vector2(636, 231)
 scale = Vector2(-0.719015, 19.8856)
 
 [node name="Wall3" parent="." instance=ExtResource("3_8g0g3")]
-position = Vector2(382, 422)
-rotation = 1.5697
-scale = Vector2(-0.719015, 24.806)
+position = Vector2(385, 422)
+rotation = 1.5708
+scale = Vector2(-0.72, 24.84)
 
 [node name="Wall4" parent="." instance=ExtResource("3_8g0g3")]
 position = Vector2(382, 40)
 rotation = 1.5697
 scale = Vector2(-0.719015, 24.806)
 
-[connection signal="client_connected" from="MultiplayerConnection" to="Players" method="_on_multiplayer_connection_client_connected"]
-[connection signal="client_disconnected" from="MultiplayerConnection" to="Players" method="_on_multiplayer_connection_client_disconnected"]
+[connection signal="client_connected" from="HUD/MultiplayerConnection" to="Players" method="_on_multiplayer_connection_client_connected"]
+[connection signal="client_disconnected" from="HUD/MultiplayerConnection" to="Players" method="_on_multiplayer_connection_client_disconnected"]


### PR DESCRIPTION
This is a UI tweak dependent on #6, and targets the related source branch.

### Before
![image](https://github.com/user-attachments/assets/9a5f7aed-2c9a-4523-b0cf-9154ed9e5691)

### After
![image](https://github.com/user-attachments/assets/3383e127-59b9-48de-b302-880169052e55)

### Changes Summary
- multiplayer_connection.tscn:
	- Redefine parent node as a "Control" Node type
	- Add an "HBoxContainer, named "Connect", and center with anchors
	- Re-parent ConnectBtn and HostInput to Connect
	- Add a "ServerIP" Label node, child of Connect
	- Add an 8x8px spacer node, child of Connect

- multiplayer_connection.gd
	- Update paths to nodes
	- Add $Connect.show() and $Connect.hide() to button update function, and always hide for the server instance.

- main.tscn:
	- Create a "CanvasLayer", named "HUD"
	- Reparent "MultiplayerConnection" to "HUD" and set anchors to "Full Rect"
	- Fiddle with Wall3's positioning...